### PR TITLE
Change concat method to loop push in File prototype to increase speed

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -52,7 +52,9 @@ File.prototype = {
     write: function (content) {
         var lines = getLines(String(content));
         this._content[this._content.length - 1] += lines.shift();
-        this._content = this._content.concat(lines);
+        for (var i = 0, len = lines.length; i < len; ++i) {
+            this._content.push(lines[i]);
+        }
 
         return this;
     },


### PR DESCRIPTION
cc @blond 

This change will helps to increase speed of bundles making. I'm using loop instead of `arr.push.apply(arr, arr2)` because of issues with apply when array is bigger then 150000 elements.

https://jsperf.com/array-extending-push-vs-concat
